### PR TITLE
Fix main key in package.json that caused node to fail at importing scribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "url": "https://github.com/bluejamesbond/Scribe.js/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "lib/scribe.js",
+  "main": "scribe.js",
   "scripts": {
     "test": "grunt nodeunit"
   },


### PR DESCRIPTION
See title
